### PR TITLE
Fixed oversized buttons on smaller screens

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -54,7 +54,7 @@ h1{
 	bottom: 1em;
 }
 
-.action-button.waiting-room{
+.action-button.fixed-width{
 	width: 8.5em;
 }
 

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -54,6 +54,10 @@ h1{
 	bottom: 1em;
 }
 
+.action-button.waiting-room{
+	width: 8.5em;
+}
+
 .top-button{
 	bottom:80px;
 }

--- a/web/js/components/Menu.jsx
+++ b/web/js/components/Menu.jsx
@@ -105,10 +105,10 @@ export class WaitingRoom extends React.Component {
             </div>
             {this.props.isHost ? 
               <div>
-                <button className="action-button top-button" onClick={this.toggleModal}>
+                <button className="action-button top-button fixed-width" onClick={this.toggleModal}>
                 Share Game
                 </button>
-                <button className="action-button bottom-button" onClick={this.startGameButtonPressed}>
+                <button className="action-button bottom-button fixed-width" onClick={this.startGameButtonPressed}>
                 Start Game
                 </button>
               </div> : null}

--- a/web/js/components/ReadSupers.jsx
+++ b/web/js/components/ReadSupers.jsx
@@ -32,7 +32,7 @@ export default class ReadSupers extends React.Component {
             <div>
               <Loader statusText="That's it!" />
               <button   onClick={this.newGameButtonPressed}
-                        className="btn-lg action-button">
+                        className="btn-lg action-button fixed-width">
                 Go to menu
               </button>
             </div> : 

--- a/web/js/main.jsx
+++ b/web/js/main.jsx
@@ -185,7 +185,7 @@ return(<div className="custom-button waitingroom">{player}</div>)
 
   login(type){
 
-    const socket = type==='host' ? `ws://${location.host}/ws?name=${this.state.playerName}` : `ws://${location.host}/ws?name=${this.state.playerName}&game=${this.state.gameId}`
+    const socket = type==='host' ? `wss://${location.host}/ws?name=${this.state.playerName}` : `wss://${location.host}/ws?name=${this.state.playerName}&game=${this.state.gameId}`
 
     const webSocket = new WebSocket(socket)
 

--- a/web/js/main.jsx
+++ b/web/js/main.jsx
@@ -185,7 +185,7 @@ return(<div className="custom-button waitingroom">{player}</div>)
 
   login(type){
 
-    const socket = type==='host' ? `wss://${location.host}/ws?name=${this.state.playerName}` : `wss://${location.host}/ws?name=${this.state.playerName}&game=${this.state.gameId}`
+    const socket = type==='host' ? `ws://${location.host}/ws?name=${this.state.playerName}` : `ws://${location.host}/ws?name=${this.state.playerName}&game=${this.state.gameId}`
 
     const webSocket = new WebSocket(socket)
 


### PR DESCRIPTION
The following buttons are not wide enough on smaller screens causing buttons to overlap:
- Share game (waiting room)
- Start game (waiting room)
- Go to menu (Read Supers screen)