### PR TITLE
Added send feedback flow

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -51,11 +51,6 @@ h1{
 	width: 9.7em;
 	padding: 0.3em 1.5em;
 }
-/*
-.action-button.fixed-width{
-	width: 8.5em;
-	padding: 0.3em 1.5em;
-}*/
 
 .top-button{
 	bottom:80px;
@@ -174,13 +169,11 @@ h1{
 }
 
 .superlative{
-	display: flex;
 	align-items: center;
 	justify-content: center;
 	padding-left: 1em;
 	padding-right: 1em;
 	height: 42%;
-	overflow: scroll;
 	font-size:2.5em;
 	font-weight: 700;
 }
@@ -212,6 +205,11 @@ h1{
 		height: 34px;
 		width: 34px;
 		line-height: 34px;
+	}
+
+	.superlative{
+	display: flex;
+	overflow: scroll;
 	}
 }
 

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -183,6 +183,16 @@ h1{
 	font-weight: 700;
 }
 
+.help-box{
+	position: fixed;
+	background: #FFFFFF;
+	border-radius: 6px;
+	font-family: Barlow;
+	font-weight: 700;
+	font-size: 27px;
+	color: #2F3A3A;
+}
+
 /*Small screens*/
 @media only screen and (max-width: 768px){
 	.ReactModal__Content--after-open{
@@ -192,6 +202,14 @@ h1{
 		right: 10px;
 		height: auto !important;
 		bottom: auto !important;
+	}
+
+	.help-box{
+		left: 0.5em;
+		bottom: 0.5em;
+		height: 34px;
+		width: 34px;
+		line-height: 34px;
 	}
 }
 
@@ -206,6 +224,14 @@ h1{
 
 	.container {
 	width: 30em;
+	}
+
+	.help-box{
+		right: 0.5em;
+		top: 0.5em;
+		height: 34px;
+		width: 34px;
+		line-height: 34px;
 	}
 }
 

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -47,13 +47,15 @@ h1{
 	font-weight: 500;
 	border-radius: 60px;
 	border: 0px;
-	padding: 0.3em 1.5em;
 	transform: translateX(-50%);
+	width: 9.7em;
+	padding: 0.3em 1.5em;
 }
-
+/*
 .action-button.fixed-width{
 	width: 8.5em;
-}
+	padding: 0.3em 1.5em;
+}*/
 
 .top-button{
 	bottom:80px;
@@ -177,7 +179,7 @@ h1{
 	justify-content: center;
 	padding-left: 1em;
 	padding-right: 1em;
-	height: 57%;
+	height: 42%;
 	overflow: scroll;
 	font-size:2.5em;
 	font-weight: 700;
@@ -205,8 +207,8 @@ h1{
 	}
 
 	.help-box{
-		left: 0.5em;
-		bottom: 0.5em;
+		left: 0.3em;
+		bottom: 0.3em;
 		height: 34px;
 		width: 34px;
 		line-height: 34px;
@@ -241,22 +243,23 @@ h1{
 	font-size: 1.2em;
 }
 
-.subtitle.next-super{
+.subtitle{
 	display: block;
 	position: fixed;
 	width: 80%;
 	left: 50%;
 	transform: translateX(-50%);
-	bottom: 4.5em;
 	font-size: 17px;
 	color: rgba(255,255,255,0.33);
 }
 
-.subtitle.hide-modal{
-	display: block;
-	position: relative;
-	color: rgba(255,255,255,0.3);
-	margin: 0 auto;
+.subtitle.next-super{
+	bottom: 8em;
+}
+
+.subtitle.read-count{
+	bottom:11em;
+	color: white;
 }
 
 .share-text{

--- a/web/js/components/FeedbackModal.jsx
+++ b/web/js/components/FeedbackModal.jsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+export default class FeedbackModal extends React.Component {
+  constructor(props){
+    super(props)
+    this.onSubmit = this.onSubmit.bind(this)
+  }
+
+  render(){
+    return(
+          <div>
+          <div className="description join">Send us feedback</div>
+            <form onSubmit={this.onSubmit}>
+              <label style={{display:'block'}}>
+                <input  type="text"
+                        value={this.props.feedbackMessage}
+                        onChange={this.props.onChange}
+                        className="form-control"
+                        />
+              </label>
+              <input  type="submit"
+                      value="Send"
+                      className="custom-button join" />
+            </form>
+          </div>
+    )
+  }
+
+  onSubmit(e){
+    e.preventDefault();
+    this.props.onSubmit(this.props.feedbackMessage)
+  }
+}

--- a/web/js/components/ReadSupers.jsx
+++ b/web/js/components/ReadSupers.jsx
@@ -36,11 +36,11 @@ export default class ReadSupers extends React.Component {
             <div>
               <Loader statusText="That's it!" />
               <button   onClick={this.backToAwardsButtonPressed}
-                        className="btn-lg end-game-button">
+                        className="action-button top-button">
                 Back to awards
               </button>
               <button   onClick={this.newGameButtonPressed}
-                        className="btn-lg end-game-button">
+                        className="action-button bottom-button">
                 Go to menu
               </button>
               
@@ -48,14 +48,14 @@ export default class ReadSupers extends React.Component {
             <div>
               <div className="description">Here's what your friends assigned you:</div>
               <div className="superlative">{this.props.supers[this.state.position]}</div>
-              <div className="read-count">{this.state.position+1}/{this.props.supers.length}</div>
+              <div className="subtitle read-count">{this.state.position+1}/{this.props.supers.length}</div>
               <div className="subtitle next-super">Wait for everyone to read one before going to the next.</div>
               <button   onClick={this.previousButtonClicked} 
-                        className="btn-lg read-nav-button previous-button">
+                        className="action-button bottom-button">
                         Previous
               </button>
               <button   onClick={this.nextButtonClicked} 
-                        className="btn-lg read-nav-button next-button">
+                        className="action-button top-button">
                         Next
               </button>
             </div>}

--- a/web/js/components/ReadSupers.jsx
+++ b/web/js/components/ReadSupers.jsx
@@ -51,11 +51,11 @@ export default class ReadSupers extends React.Component {
               <div className="subtitle read-count">{this.state.position+1}/{this.props.supers.length}</div>
               <div className="subtitle next-super">Wait for everyone to read one before going to the next.</div>
               <button   onClick={this.previousButtonClicked} 
-                        className="action-button bottom-button">
+                        className="btn-lg read-nav-button previous-button">
                         Previous
               </button>
               <button   onClick={this.nextButtonClicked} 
-                        className="action-button top-button">
+                        className="btn-lg read-nav-button next-button">
                         Next
               </button>
             </div>}

--- a/web/js/components/WriteSupers.jsx
+++ b/web/js/components/WriteSupers.jsx
@@ -100,8 +100,8 @@ export default class WriteSupers extends React.Component {
                     {this.props.isHost ? <div><form onSubmit={this.showSubmitModal}>
                     <label>
                       <input  type="submit"
-                              value="Stop timer and continue"
-                              className="btn btn-warning action-button bottom-button"/>
+                              value="Stop timer"
+                              className="action-button bottom-button fixed-width"/>
                     </label>
                     </form></div> : null}</div>
                   }    


### PR DESCRIPTION
Notes:
- In the Read stage,
-- adjusted height for superlative div
-- changed subtitle and superlative position tracker to be fixed
-- changed Next and Previous buttons style to match top and bottom buttons in other stages
-- actually added CSS class for the position tracker
- In the Write stage, changed copy from "Stop timer and continue" to "Stop timer". Rationale: shorter button copy works better on all devices, and when you tap it, you're seen a confirmation modal anyway before you take any action
- Added a new ? button to access onboarding and send feedback
- On mobile, there are two stages where the new ? button overlaps existing buttons. I've created a separate Trello card to fix that.

Design mock of help button:
<img width="326" alt="screenshot 2018-01-11 21 35 17" src="https://user-images.githubusercontent.com/12538763/34858692-5e01625a-f717-11e7-91a2-cb899f1fdca3.png">
<img width="642" alt="screenshot 2018-01-11 21 35 27" src="https://user-images.githubusercontent.com/12538763/34858695-5f9da72c-f717-11e7-8289-86a4dc436034.png">