### PR TITLE
Clear input fields on submit

### DIFF
--- a/web/js/components/WriteSupers.jsx
+++ b/web/js/components/WriteSupers.jsx
@@ -45,8 +45,8 @@ export default class WriteSupers extends React.Component {
       this.moveToAssign(e);
     } else {
       // Timer still running. Submit super to server.
-      this.setState({super:""})
       this.props.submitSuper(this.state.super)
+      this.setState({super:""})
     }
   }
 

--- a/web/js/main.jsx
+++ b/web/js/main.jsx
@@ -423,6 +423,7 @@ return(<div className="custom-button waitingroom">{player}</div>)
         })
         this.stopPing();
         this.state.socket.close();
+        this.setState({gameId:""})
         this.state.socket.onclose = function(event){
           console.log("Socket closed!");
         };


### PR DESCRIPTION
- Fixed issue where we were clearing super's value before submitting it to the back-end. We didn't catch it sooner because the setState function that resets the value is an async function
- Cleared gameId state when websocket is closed so that the game code input field in the Join Game modal is clear when you start a second game
- Clear input field in Feedback modal on submit