### PR TITLE
add game_id column, log player stats on socket close

### DIFF
--- a/tables.py
+++ b/tables.py
@@ -21,6 +21,7 @@ player_stats = Table(
     Column('open_ts', Integer),
     Column('close_ts', Integer),
     Column('state', String),
+    Column('game_id', String),
 )
 
 
@@ -31,6 +32,11 @@ async def create_player_stats_table(conn):
         close_ts bigint DEFAULT NULL,
         state varchar(255) DEFAULT NULL
     )''')
+
+
+async def add_game_id_player_stats(conn):
+    return await conn.execute('''ALTER TABLE player_stats ADD COLUMN IF NOT EXISTS game_id varchar(255) DEFAULT NULL;
+    ''')
 
 
 async def async_db_call(fn):
@@ -50,4 +56,5 @@ async def async_db_call(fn):
 def setup_and_migrate_db(ioloop):
     return all([
         ioloop.run_until_complete(ensure_future(async_db_call(create_player_stats_table))),
+        ioloop.run_until_complete(ensure_future(async_db_call(add_game_id_player_stats))),
     ])


### PR DESCRIPTION
* DB migrations involve appending a new async function in the form `ioloop.run_until_complete(ensure_future(async_db_call(new_func_here))),` to the list in `setup_and_migrate_db`.  Never, ever, ever, ever, ever, ever edit a DB migration that has already been pushed to master.  The only exception is if we want to "squash" old migrations into a single initialization and remove all our migrations at once.  If/when we choose to do this, it should be its own PR.

* Any time you want to write a db call, use the sqlalchemy syntax for it with method chaining (`table_name.select.where(foo='blah')` / `table_name.insert.values(baz='quux')`) and pass it into `async_db_call`.  If you need to pass any parameters into that function, you will need to use `functools.partial` with kwargs.  The first arg and only to any function passed to `async_db_call` has to be the database connection (which is supplied by `async_db_call`.  Open to discussing expanding `async_db_call` to accept kwargs and passing them through as well, but for now I lean toward the `partial` approach.